### PR TITLE
chore: added permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   determine-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -52,6 +54,9 @@ jobs:
     needs: determine-changes
     if: ${{ needs.determine-changes.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         app: ${{ fromJson(needs.determine-changes.outputs.matrix) }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   determine-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       package: ${{ steps.set-package.outputs.package }}
       version: ${{ steps.set-package.outputs.version }}
@@ -64,6 +66,9 @@ jobs:
     needs: determine-changes
     if: ${{ needs.determine-changes.outputs.package != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Welcome
         uses: wow-actions/welcome@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to explicitly define job permissions, enhancing security and clarity.
	- Set read-only access to repository contents for CI and change-detection jobs.
	- Granted necessary write permissions for package publishing in build jobs.
	- Allowed write access to issues and pull requests for the welcome workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->